### PR TITLE
Corrected bug where removing composer death date caused backend to crash

### DIFF
--- a/backend/src/models/composers-model.mjs
+++ b/backend/src/models/composers-model.mjs
@@ -90,7 +90,7 @@ function updateComposer(composerID, composer) {
     composer.firstName,
     composer.lastName,
     composer.birthDate,
-    composer.deathDate,
+    composer.deathDate === '' ? null : composer.deathDate,
     composerID
   ];
 


### PR DESCRIPTION
Fixed line 93 in composers-model.mjs to send a null value for the death date if a blank string is recieved